### PR TITLE
EDGE-630 Add voice call id to the transfer

### DIFF
--- a/bandwidth/webrtc/utils/transfer_util.py
+++ b/bandwidth/webrtc/utils/transfer_util.py
@@ -9,11 +9,17 @@ Method to generate the transfer BXML to connect WebRTC <-> phones
 def generate_transfer_bxml(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns BXML string with WebRTC a device token to perform a SIP transfer
+    :param device_token: The device token
+    :param voice_call_id: The voice call id, used for debugging
+    :param sip_uri: The uri of the sipx, if not specified it will take the default value
     """
     return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri) + '</Response>'
 
 def generate_transfer_bxml_verb(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns the Transfer verb to perform the SIP transfer
+    :param device_token: The device token
+    :param voice_call_id: The voice call id, used for debugging
+    :param sip_uri: The uri of the sipx, if not specified it will take the default value 
     """
-    return f'''<Transfer><SipUri uui="{voice_call_id};encoding=base64,{device_token};encoding=jwt">{sip_uri}</SipUri></Transfer>'''
+    return f'''<Transfer><SipUri uui="{"".join(voice_call_id.split("-")[1::])};encoding=base64,{device_token};encoding=jwt">{sip_uri}</SipUri></Transfer>'''

--- a/bandwidth/webrtc/utils/transfer_util.py
+++ b/bandwidth/webrtc/utils/transfer_util.py
@@ -10,8 +10,8 @@ def generate_transfer_bxml(device_token, voice_call_id, sip_uri='sip:sipx.webrtc
     """
     Returns BXML string with WebRTC a device token to perform a SIP transfer
     :param device_token: The device token
-    :param voice_call_id: The voice call id, used for debugging
-    :param sip_uri: The uri of the sipx, if not specified it will take the default value
+    :param voice_call_id: The Bandwidth Voice Call Id
+    :param sip_uri: The SIP URI to transfer the call to 
     """
     return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri) + '</Response>'
 
@@ -19,7 +19,7 @@ def generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri='sip:sipx.w
     """
     Returns the Transfer verb to perform the SIP transfer
     :param device_token: The device token
-    :param voice_call_id: The voice call id, used for debugging
-    :param sip_uri: The uri of the sipx, if not specified it will take the default value 
+    :param voice_call_id: The Bandwidth Voice Call Id
+    :param sip_uri: The SIP URI to transfer the call to 
     """
     return f'''<Transfer><SipUri uui="{"".join(voice_call_id.split("-")[1::])};encoding=base64,{device_token};encoding=jwt">{sip_uri}</SipUri></Transfer>'''

--- a/bandwidth/webrtc/utils/transfer_util.py
+++ b/bandwidth/webrtc/utils/transfer_util.py
@@ -6,7 +6,7 @@ Method to generate the transfer BXML to connect WebRTC <-> phones
 @copyright Bandwidth INC
 """
 
-def generate_transfer_bxml(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
+def generate_transfer_bxml(device_token, voice_call_id, sip_uri='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns BXML string with WebRTC a device token to perform a SIP transfer
     :param device_token: The device token
@@ -15,7 +15,7 @@ def generate_transfer_bxml(device_token: str, voice_call_id: str, sip_uri: str =
     """
     return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri) + '</Response>'
 
-def generate_transfer_bxml_verb(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
+def generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns the Transfer verb to perform the SIP transfer
     :param device_token: The device token

--- a/bandwidth/webrtc/utils/transfer_util.py
+++ b/bandwidth/webrtc/utils/transfer_util.py
@@ -6,14 +6,14 @@ Method to generate the transfer BXML to connect WebRTC <-> phones
 @copyright Bandwidth INC
 """
 
-def generate_transfer_bxml(device_token, sip_uri='sip:sipx.webrtc.bandwidth.com:5060'):
+def generate_transfer_bxml(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns BXML string with WebRTC a device token to perform a SIP transfer
     """
-    return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, sip_uri) + '</Response>'
+    return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri) + '</Response>'
 
-def generate_transfer_bxml_verb(device_token, sip_uri='sip:sipx.webrtc.bandwidth.com:5060'):
+def generate_transfer_bxml_verb(device_token: str, voice_call_id: str, sip_uri: str ='sip:sipx.webrtc.bandwidth.com:5060'):
     """
     Returns the Transfer verb to perform the SIP transfer
     """
-    return f'''<Transfer><SipUri uui="{device_token};encoding=jwt">{sip_uri}</SipUri></Transfer>'''
+    return f'''<Transfer><SipUri uui="{voice_call_id};encoding=base64,{device_token};encoding=jwt">{sip_uri}</SipUri></Transfer>'''

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name='bandwidth-sdk',
-    version='10.1.0',
+    version='11.0.0',
     description='Bandwidth\'s set of APIs',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/integration/webrtc_bxml_tests.py
+++ b/tests/integration/webrtc_bxml_tests.py
@@ -15,13 +15,13 @@ class WebRtcBxmlTests(unittest.TestCase):
     Class for the WebRtc BXML tests
     """
     def test_generate_transfer_bxml(self):
-        expected = '<?xml version="1.0" encoding="UTF-8"?><Response><Transfer><SipUri uui="asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer></Response>'
-        actual = generate_transfer_bxml('asdf')
+        expected = '<?xml version="1.0" encoding="UTF-8"?><Response><Transfer><SipUri uui="93d6f3c0be5845960b744fa28015d8ede84bd1a4;encoding=base64,asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer></Response>'
+        actual = generate_transfer_bxml('asdf', 'c-93d6f3c0-be584596-0b74-4fa2-8015-d8ede84bd1a4')
         self.assertEqual(actual, expected)
     
     def test_generate_transfer_bxml_verb(self):
-        expected = '<Transfer><SipUri uui="asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer>'
-        actual = generate_transfer_bxml_verb('asdf')
+        expected = '<Transfer><SipUri uui="93d6f3c0be5845960b744fa28015d8ede84bd1a4;encoding=base64,asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer>'
+        actual = generate_transfer_bxml_verb('asdf', 'c-93d6f3c0-be584596-0b74-4fa2-8015-d8ede84bd1a4')
         self.assertEqual(actual, expected)
 
 


### PR DESCRIPTION
If the DX team could add some tests as needed, that would be wonderful. Please note that the hyphens and leading c get stripped out before getting put in the transfer.

This is a breaking change so it should go out with a major version bump!