### PR TITLE
DX-2454 Update OpenAPI Config Version

### DIFF
--- a/openapi-config.yml
+++ b/openapi-config.yml
@@ -1,4 +1,4 @@
 projectName: bandwidth-sdk
 packageName: bandwidth
-packageVersion: 14.0.0
+packageVersion: 1.0.0
 packageUrl: 'https://dev.bandwidth.com/sdks/python'


### PR DESCRIPTION
set pakage version to always be 1.0.0 - we will set this in the deployment logic