### PR TITLE
EDGE-1027 removed unnecessary participants from subscription object

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ except APIException as e:
 ```python
 web_rtc_client = bandwidth_client.web_rtc_client.client
 
-participant1 = {'participantId': '456'}
-participant2 = {'participantId': '789', 'streamAliases': ['alias1', 'alias2']}
-subscriptions = {'sessionId': session_id_arg, 'participants': [participant1, participant2]}
+subscriptions = {'sessionId': session_id_arg}
 
 create_session_body = Session()
 create_session_body.tag = 'new-session'


### PR DESCRIPTION
The way the API works, if you only supply a session ID in the subscriptions argument, you will automatically be subscribed to all participants in a session. This makes supplying participant ids unnecessary in this case, which is why I have removed them.