### PR TITLE
task/Update models to be python version agnostic

### DIFF
--- a/bandwidth/model/bxml/verbs/phone_number.py
+++ b/bandwidth/model/bxml/verbs/phone_number.py
@@ -33,17 +33,17 @@ class PhoneNumber(Verb):
             tag (str, optional):  A custom string that will be sent with these and all future callbacks unless overwritten by a future tag attribute or cleared. May be cleared by setting tag="" Max length 256 characters. Defaults to None.
         """
         self.attributes = {
-            "fallbackPassword": fallback_password,
-            "fallbackUsername": fallback_username,
-            "password": password,
-            "tag": tag,
-            "transferAnswerFallbackMethod": transfer_answer_fallback_method,
-            "transferAnswerFallbackUrl": transfer_answer_fallback_url,
-            "transferAnswerMethod": transfer_answer_method,
             "transferAnswerUrl": transfer_answer_url,
-            "transferDisconnectMethod": transfer_disconnect_method,
+            "transferAnswerMethod": transfer_answer_method,
+            "transferAnswerFallbackUrl": transfer_answer_fallback_url,
+            "transferAnswerFallbackMethod": transfer_answer_fallback_method,
             "transferDisconnectUrl": transfer_disconnect_url,
-            "username": username
+            "transferDisconnectMethod": transfer_disconnect_method,
+            "username": username,
+            "password": password,
+            "fallbackUsername": fallback_username,
+            "fallbackPassword": fallback_password,
+            "tag": tag
         }
         super().__init__(
             tag="PhoneNumber",

--- a/bandwidth/model/bxml/verbs/sip_uri.py
+++ b/bandwidth/model/bxml/verbs/sip_uri.py
@@ -34,18 +34,18 @@ class SipUri(Verb):
             tag (str, optional):  A custom string that will be sent with these and all future callbacks unless overwritten by a future tag attribute or cleared. May be cleared by setting tag="" Max length 256 characters. Defaults to None.
         """
         self.attributes = {
-            "fallbackPassword": fallback_password,
-            "fallbackUsername": fallback_username,
-            "password": password,
-            "tag": tag,
-            "transferAnswerFallbackMethod": transfer_answer_fallback_method,
-            "transferAnswerFallbackUrl": transfer_answer_fallback_url,
-            "transferAnswerMethod": transfer_answer_method,
+            "uui": uui,
             "transferAnswerUrl": transfer_answer_url,
-            "transferDisconnectMethod": transfer_disconnect_method,
+            "transferAnswerMethod": transfer_answer_method,
+            "transferAnswerFallbackUrl": transfer_answer_fallback_url,
+            "transferAnswerFallbackMethod": transfer_answer_fallback_method,
             "transferDisconnectUrl": transfer_disconnect_url,
+            "transferDisconnectMethod": transfer_disconnect_method,
             "username": username,
-            "uui": uui
+            "password": password,
+            "fallbackUsername": fallback_username,
+            "fallbackPassword": fallback_password,
+            "tag": tag
         }
         super().__init__(
             tag="SipUri",

--- a/bandwidth/model/bxml/verbs/transfer.py
+++ b/bandwidth/model/bxml/verbs/transfer.py
@@ -62,19 +62,19 @@ class Transfer(Verb):
                 Defaults to None.
         """
         self.attributes = {
-            "callTimeout": call_timeout,
-            "diversionReason": diversion_reason,
-            "diversionTreatment": diversion_treatment,
-            "fallbackPassword": fallback_password,
-            "fallbackUsername": fallback_username,
-            "password": password,
-            "tag": tag,
             "transferCallerId": transfer_caller_id,
-            "transferCompleteFallbackMethod": transfer_complete_fallback_method,
-            "transferCompleteFallbackUrl": transfer_complete_fallback_url,
-            "transferCompleteMethod": transfer_complete_method,
+            "callTimeout": call_timeout,
             "transferCompleteUrl": transfer_complete_url,
-            "username": username
+            "transferCompleteMethod": transfer_complete_method,
+            "transferCompleteFallbackUrl": transfer_complete_fallback_url,
+            "transferCompleteFallbackMethod": transfer_complete_fallback_method,
+            "username": username,
+            "password": password,
+            "fallbackUsername": fallback_username,
+            "fallbackPassword": fallback_password,
+            "tag": tag,
+            "diversionTreatment": diversion_treatment,
+            "diversionReason": diversion_reason
         }
         super().__init__(
             tag="Transfer",

--- a/test/unit/bxml/test_phone_number.py
+++ b/test/unit/bxml/test_phone_number.py
@@ -18,9 +18,9 @@ class TestPhoneNumber(unittest.TestCase):
     def setUp(self):
         self.phone_number = PhoneNumber(
             number="+19195551234",
-            transfer_answer_url="https://example.com/webhooks/transfer_answer"
+            transfer_answer_url="https://example.com/webhooks/transfer_answer",
             transfer_answer_method="POST",
-            tag="",
+            tag=""
         )
         self.test_verb = Verb(tag="test")
     

--- a/test/unit/bxml/test_phone_number.py
+++ b/test/unit/bxml/test_phone_number.py
@@ -5,6 +5,7 @@ Unit tests for the <PhoneNumber> BXML verb
 
 @copyright Bandwidth Inc.
 """
+import os
 import pytest
 import unittest
 
@@ -17,14 +18,18 @@ class TestPhoneNumber(unittest.TestCase):
     def setUp(self):
         self.phone_number = PhoneNumber(
             number="+19195551234",
-            tag="",
-            transfer_answer_method="POST",
             transfer_answer_url="https://example.com/webhooks/transfer_answer"
+            transfer_answer_method="POST",
+            tag="",
         )
         self.test_verb = Verb(tag="test")
     
     def test_to_bxml(self):
-        expected = '<PhoneNumber tag="" transferAnswerMethod="POST" transferAnswerUrl="https://example.com/webhooks/transfer_answer">+19195551234</PhoneNumber>'
+        if os.environ['PYTHON_VERSION'] == '3.7':
+            expected = '<PhoneNumber tag="" transferAnswerMethod="POST" transferAnswerUrl="https://example.com/webhooks/transfer_answer">+19195551234</PhoneNumber>'
+        else:
+            expected = '<PhoneNumber transferAnswerUrl="https://example.com/webhooks/transfer_answer" transferAnswerMethod="POST" tag="">+19195551234</PhoneNumber>'
+            
         assert(expected == self.phone_number.to_bxml())
     
     def test_add_verb(self):

--- a/test/unit/bxml/test_sip_uri.py
+++ b/test/unit/bxml/test_sip_uri.py
@@ -19,7 +19,7 @@ class TestSipUri(unittest.TestCase):
         self.phone_number = SipUri(
             uri="sip:1-999-123-4567@voip-provider.example.net",
             uui="abc123",
-            transfer_answer_url="https://example.com/webhooks/transfer_answer"
+            transfer_answer_url="https://example.com/webhooks/transfer_answer",
             transfer_answer_method="POST",
             tag="test"
         )

--- a/test/unit/bxml/test_sip_uri.py
+++ b/test/unit/bxml/test_sip_uri.py
@@ -5,6 +5,7 @@ Unit tests for the <SipUri> BXML verb
 
 @copyright Bandwidth Inc.
 """
+import os
 import pytest
 import unittest
 
@@ -17,15 +18,18 @@ class TestSipUri(unittest.TestCase):
     def setUp(self):
         self.phone_number = SipUri(
             uri="sip:1-999-123-4567@voip-provider.example.net",
-            tag="test",
+            uui="abc123",
+            transfer_answer_url="https://example.com/webhooks/transfer_answer"
             transfer_answer_method="POST",
-            transfer_answer_url="https://example.com/webhooks/transfer_answer",
-            uui="abc123"
+            tag="test"
         )
         self.test_verb = Verb(tag="test")
     
     def test_to_bxml(self):
-        expected = '<SipUri tag="test" transferAnswerMethod="POST" transferAnswerUrl="https://example.com/webhooks/transfer_answer" uui="abc123">sip:1-999-123-4567@voip-provider.example.net</SipUri>'
+        if os.environ['PYTHON_VERSION'] == '3.7':
+            expected = '<SipUri tag="test" transferAnswerMethod="POST" transferAnswerUrl="https://example.com/webhooks/transfer_answer" uui="abc123">sip:1-999-123-4567@voip-provider.example.net</SipUri>'
+        else:
+            expected = '<SipUri uui="abc123" transferAnswerUrl="https://example.com/webhooks/transfer_answer" transferAnswerMethod="POST" tag="test">sip:1-999-123-4567@voip-provider.example.net</SipUri>'
         assert(expected == self.phone_number.to_bxml())
     
     def test_add_verb(self):

--- a/test/unit/bxml/test_transfer.py
+++ b/test/unit/bxml/test_transfer.py
@@ -5,6 +5,7 @@ Unit tests for the <PhoneNumber> BXML verb
 
 @copyright Bandwidth Inc.
 """
+import os
 import pytest
 import unittest
 
@@ -27,15 +28,21 @@ class TestTransfer(unittest.TestCase):
         self.transfer = Transfer(
             transfer_to=[self.sip_uri],
             call_timeout = "15",
-            tag = "test",
-            transfer_caller_id = "+19195554321"
+            transfer_caller_id = "+19195554321",
+            tag = "test"
         )
     
     def test_to_bxml(self):
-        expected = '<Transfer callTimeout="15" tag="test" transferCallerId="+19195554321"><SipUri uui="test">sip@bw.com</SipUri></Transfer>'
+        if os.environ['PYTHON_VERSION'] == '3.7':
+            expected = '<Transfer callTimeout="15" tag="test" transferCallerId="+19195554321"><SipUri uui="test">sip@bw.com</SipUri></Transfer>'
+        else:
+            expected = '<Transfer transferCallerId="+19195554321" callTimeout="15" tag="test"><SipUri uui="test">sip@bw.com</SipUri></Transfer>'
         assert(expected == self.transfer.to_bxml())
     
     def test_add_verb(self):
-        expected = '<Transfer callTimeout="15" tag="test" transferCallerId="+19195554321"><SipUri uui="test">sip@bw.com</SipUri><PhoneNumber tag="test">+19195551234</PhoneNumber></Transfer>'
+        if os.environ['PYTHON_VERSION'] == '3.7':
+            expected = '<Transfer callTimeout="15" tag="test" transferCallerId="+19195554321"><SipUri uui="test">sip@bw.com</SipUri><PhoneNumber tag="test">+19195551234</PhoneNumber></Transfer>'
+        else:
+            expected = '<Transfer transferCallerId="+19195554321" callTimeout="15" tag="test"><SipUri uui="test">sip@bw.com</SipUri><PhoneNumber tag="test">+19195551234</PhoneNumber></Transfer>'
         self.transfer.add_transfer_recipient(self.phone_number)
         assert(expected == self.transfer.to_bxml())


### PR DESCRIPTION
Handling of different version behavior should be handled in the tests since the dict ordering behavior in 3.7 has no effect on how the backend handles the serialized xml. order of attributes is unimportant