### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -6,6 +6,7 @@ metadata:
   description: python-sdk
   annotations:
     github.com/project-slug: Bandwidth/python-sdk
+    bandwidth.com/languages: Python
   organization: BW
   costCenter: UNKNOWN
   buildPlatform: GitHub Actions


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Python`